### PR TITLE
Fixes issues in macro version of OrientationJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>ch.epfl.big</groupId>
 	<artifactId>OrientationJ_</artifactId>
-	<version>2.0.4</version>
+	<version>2.0.5</version>
 
 	<name>OrientationJ</name>
 	<description>OrientationJ: ImageJ plugins for directional image analysis - http://bigwww.epfl.ch/demo/orientation/</description>

--- a/src/main/java/OrientationJ_Clustering.java
+++ b/src/main/java/OrientationJ_Clustering.java
@@ -41,10 +41,7 @@ import gui_orientation.AnalysisDialog;
 import gui_orientation.WalkBarOrientationJ;
 import ij.Macro;
 import ij.plugin.PlugIn;
-import orientation.GroupImage;
-import orientation.OrientationParameters;
-import orientation.OrientationProcess;
-import orientation.OrientationService;
+import orientation.*;
 import orientation.imageware.ImageWare;
 
 public class OrientationJ_Clustering implements PlugIn {
@@ -69,6 +66,8 @@ public class OrientationJ_Clustering implements PlugIn {
 			WalkBarOrientationJ walk = new WalkBarOrientationJ();
 			OrientationProcess process = new OrientationProcess(walk, source, params);
 			process.run();
+			OrientationResults.show(process.getGroupImage(), params, 1);
+
 		}
 	}
 }

--- a/src/main/java/OrientationJ_Distribution.java
+++ b/src/main/java/OrientationJ_Distribution.java
@@ -71,8 +71,8 @@ public class OrientationJ_Distribution implements PlugIn {
 			OrientationProcess process = new OrientationProcess(walk, source, params);
 			process.run();
 			OrientationResults.show(process.getGroupImage(), params, 1);
-			OrientationResults.plotDistribution(process.getGroupImage(), params, 1);
-			OrientationResults.tableDistribution(process.getGroupImage(), params, 1);
+			//OrientationResults.plotDistribution(process.getGroupImage(), params, 1);
+			//OrientationResults.tableDistribution(process.getGroupImage(), params, 1);
 		}
 	}
 }

--- a/src/main/java/OrientationJ_Vector_Field.java
+++ b/src/main/java/OrientationJ_Vector_Field.java
@@ -41,10 +41,7 @@ import gui_orientation.AnalysisDialog;
 import gui_orientation.WalkBarOrientationJ;
 import ij.Macro;
 import ij.plugin.PlugIn;
-import orientation.GroupImage;
-import orientation.OrientationParameters;
-import orientation.OrientationProcess;
-import orientation.OrientationService;
+import orientation.*;
 import orientation.imageware.ImageWare;
 
 public class OrientationJ_Vector_Field implements PlugIn {
@@ -69,6 +66,8 @@ public class OrientationJ_Vector_Field implements PlugIn {
 			WalkBarOrientationJ walk = new WalkBarOrientationJ();
 			OrientationProcess process = new OrientationProcess(walk, source, params);
 			process.run();
+			OrientationResults.show(process.getGroupImage(), params, 1);
+
 		}
 	}
 }


### PR DESCRIPTION
OrientationJ Distribution had an incorrect behavior when recorded from a macro

OrientationJ Vector Field did not show any results when run with a macro

This takes care of bumping the version number to a new minor version